### PR TITLE
Fix route53 terraform error

### DIFF
--- a/infra/route53/certificate.tf
+++ b/infra/route53/certificate.tf
@@ -1,18 +1,18 @@
 resource "aws_acm_certificate" "shon_diaz" {
   domain_name               = "*.${local.public_domain}"
   validation_method         = "DNS"
-  subject_alternative_names = ["${local.public_domain}"]
+  subject_alternative_names = [local.public_domain]
 }
 
 resource "aws_route53_record" "shon_diaz_cert_validation" {
-  name    = aws_acm_certificate.shon_diaz.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.shon_diaz.domain_validation_options.0.resource_record_type
+  name    = tolist(aws_acm_certificate.shon_diaz.domain_validation_options)[0].resource_record_name
+  type    = tolist(aws_acm_certificate.shon_diaz.domain_validation_options)[0].resource_record_type
   zone_id = aws_route53_zone.shon_diaz.id
-  records = ["${aws_acm_certificate.shon_diaz.domain_validation_options.0.resource_record_value}"]
+  records = [tolist(aws_acm_certificate.shon_diaz.domain_validation_options)[0].resource_record_value]
   ttl     = 60
 }
 
 resource "aws_acm_certificate_validation" "shon_diaz" {
   certificate_arn         = aws_acm_certificate.shon_diaz.arn
-  validation_record_fqdns = ["${aws_route53_record.shon_diaz_cert_validation.fqdn}"]
+  validation_record_fqdns = [aws_route53_record.shon_diaz_cert_validation.fqdn]
 }


### PR DESCRIPTION
Ran intro this error; 

```
Error: Invalid index

  on certificate.tf line 9, in resource "aws_route53_record" "shon_diaz_cert_validation":
   9:   type    = aws_acm_certificate.shon_diaz.domain_validation_options.0.resource_record_type

This value does not have any indices.
```

I know I eventually need to update the terraform version, but for the time being... lets get past this